### PR TITLE
Hide lonely meetings

### DIFF
--- a/MeetingBar.xcodeproj/project.pbxproj
+++ b/MeetingBar.xcodeproj/project.pbxproj
@@ -125,19 +125,19 @@
 		144C017B2462D0C3000C9FFC /* MeetingBar */ = {
 			isa = PBXGroup;
 			children = (
+				144C017C2462D0C3000C9FFC /* AppDelegate.swift */,
 				14E4110D246F2F9200F73ACF /* PreferencesView.swift */,
 				148E47E724F400C400399929 /* OnboardingView.swift */,
-				144C017C2462D0C3000C9FFC /* AppDelegate.swift */,
-				144C01802462D0C5000C9FFC /* Assets.xcassets */,
-				140D843B2493B7A50055E1CE /* Extensions */,
 				140D84312493A3FE0055E1CE /* StatusBarItemControler.swift */,
-				144C01852462D0C5000C9FFC /* Main.storyboard */,
-				144C01882462D0C5000C9FFC /* Info.plist */,
 				140D84332493A4180055E1CE /* Constants.swift */,
-				144C01892462D0C5000C9FFC /* MeetingBar.entitlements */,
 				140D84392493A6240055E1CE /* Helpers.swift */,
 				14879B2A24E6889C00DB0A7E /* Notifications.swift */,
+				140D843B2493B7A50055E1CE /* Extensions */,
 				144C01822462D0C5000C9FFC /* Preview Content */,
+				144C01852462D0C5000C9FFC /* Main.storyboard */,
+				144C01882462D0C5000C9FFC /* Info.plist */,
+				144C01802462D0C5000C9FFC /* Assets.xcassets */,
+				144C01892462D0C5000C9FFC /* MeetingBar.entitlements */,
 			);
 			path = MeetingBar;
 			sourceTree = "<group>";

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -26,6 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     var eventTitleFormatObserver: DefaultsObservation?
     var pastEventsAppereanceObserver: DefaultsObservation?
     var declinedEventsAppereanceObserver: DefaultsObservation?
+    var personalEventsAppereanceObserver: DefaultsObservation?
     var showEventsForPeriodObserver: DefaultsObservation?
     var joinEventNotificationObserver: DefaultsObservation?
     var launchAtLoginObserver: DefaultsObservation?
@@ -131,6 +132,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
         declinedEventsAppereanceObserver = Defaults.observe(.declinedEventsAppereance) { change in
             NSLog("Changed declinedEventsAppereance from \(change.oldValue) to \(change.newValue)")
+            self.statusBarItem.updateMenu()
+        }
+        personalEventsAppereanceObserver = Defaults.observe(.personalEventsAppereance) { change in
+            NSLog("Changed personalEventsAppereance from \(change.oldValue) to \(change.newValue)")
             self.statusBarItem.updateMenu()
         }
         showEventsForPeriodObserver = Defaults.observe(.showEventsForPeriod) { change in
@@ -267,7 +272,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             preferencesWindow.close()
         }
         preferencesWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 570, height: 460),
+            contentRect: NSRect(x: 0, y: 0, width: 570, height: 500),
             styleMask: [.closable, .titled],
             backing: .buffered,
             defer: false

--- a/MeetingBar/DefaultsKeys.swift
+++ b/MeetingBar/DefaultsKeys.swift
@@ -30,6 +30,7 @@ extension Defaults.Keys {
     static let showEventDetails = Key<Bool>("showEventDetails", default: false)
     static let declinedEventsAppereance = Key<DeclinedEventsAppereance>("declinedEventsAppereance", default: .strikethrough)
     static let pastEventsAppereance = Key<PastEventsAppereance>("pastEventsAppereance", default: .show_inactive)
+    static let personalEventsAppereance = Key<PastEventsAppereance>("personalEventsAppereance", default: .show_active)
     static let disablePastEvents = Key<Bool?>("disablePastEvents")
     static let timeFormat = Key<TimeFormat>("timeFormat", default: .military)
 

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -56,7 +56,13 @@ extension EKEventStore {
         }
 
         let predicate = predicateForEvents(withStart: startPeriod, end: endPeriod, calendars: calendars)
-        let nextEvents = events(matching: predicate)
+        var nextEvents = events(matching: predicate)
+
+        // Filter out personal events, if not marked as 'active'
+        if Defaults[.personalEventsAppereance] != .show_active {
+            nextEvents = nextEvents.filter { $0.hasAttendees }
+        }
+
         // If the current event is still going on,
         // but the next event is closer than 10 minutes later
         // then show the next event

--- a/MeetingBar/PreferencesView.swift
+++ b/MeetingBar/PreferencesView.swift
@@ -201,6 +201,7 @@ struct Appearance: View {
     @Default(.timeFormat) var timeFormat
     @Default(.showEventDetails) var showEventDetails
     @Default(.declinedEventsAppereance) var declinedEventsAppereance
+    @Default(.personalEventsAppereance) var personalEventsAppereance
     @Default(.pastEventsAppereance) var pastEventsAppereance
 
     var body: some View {
@@ -245,6 +246,13 @@ struct Appearance: View {
                     Picker("Declined events:", selection: $declinedEventsAppereance) {
                         Text("show with strikethrough").tag(DeclinedEventsAppereance.strikethrough)
                         Text("hide").tag(DeclinedEventsAppereance.hide)
+                    }
+                }
+                HStack {
+                    Picker("Events without guests:", selection: $personalEventsAppereance) {
+                        Text("show").tag(PastEventsAppereance.show_active)
+                        Text("show as inactive").tag(PastEventsAppereance.show_inactive)
+                        Text("hide").tag(PastEventsAppereance.hide)
                     }
                 }
                 HStack {

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -195,8 +195,11 @@ class StatusBarItemControler {
         }
         if event.endDate < now {
             eventItem.state = .on
-            if Defaults[.pastEventsAppereance] == .show_inactive, !Defaults[.showEventDetails] {
-                eventItem.isEnabled = false
+            if Defaults[.pastEventsAppereance] == .show_inactive {
+                eventItem.attributedTitle = NSAttributedString(
+                    string: itemTitle,
+                    attributes: [NSAttributedString.Key.foregroundColor: NSColor.disabledControlTextColor]
+                )
             }
         } else if event.startDate < now, event.endDate > now {
             eventItem.state = .mixed

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -149,16 +149,18 @@ class StatusBarItemControler {
     func createEventItem(event: EKEvent) {
         let eventStatus = getEventStatus(event)
 
+        let now = Date()
+
         if eventStatus == .declined, Defaults[.declinedEventsAppereance] == .hide {
             return
         }
 
-        let now = Date()
+        if event.endDate < now, Defaults[.pastEventsAppereance] == .hide {
+            return
+        }
 
-        if Defaults[.pastEventsAppereance] == .hide {
-            if event.endDate < now {
-                return
-            }
+        if !event.hasAttendees, Defaults[.personalEventsAppereance] == .hide {
+            return
         }
 
         let eventTitle = String(event.title)
@@ -193,6 +195,14 @@ class StatusBarItemControler {
                 attributes: [NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.thick.rawValue]
             )
         }
+
+        if !event.hasAttendees, Defaults[.personalEventsAppereance] == .show_inactive {
+            eventItem.attributedTitle = NSAttributedString(
+                string: itemTitle,
+                attributes: [NSAttributedString.Key.foregroundColor: NSColor.disabledControlTextColor]
+            )
+        }
+
         if event.endDate < now {
             eventItem.state = .on
             if Defaults[.pastEventsAppereance] == .show_inactive {


### PR DESCRIPTION
Status
READY

Description
Implements #103 "option to hide meetings with no other participants", by introducing a personalEventsAppereance setting in Defaults and the UI preferences. This applies to all events where hasAttendees is false. It offers the same three options as the setting for past events (active/inactive/hide).

Notes/things to review:

The defaults key reuses the PastEventsAppereance enum, because I used the same three options. I didn't want to create duplicated code, but now the name doesn't fully match anymore.
The filtering for the status bar title and user notifications happens in EventStore's getNextEvent. Not sure if that's the right place, but it seemed to be the only commonly used place by both.
Adding a row to Appearance in the UI required increasing the window height. This window height could maybe be made dynamic and be based on content height instead (in the future).
The name "personal events" for events without other attendees is maybe not ideal, but I didn't have any other idea. "Private event" seems to be used by calendar services for the event's visibility, "Lonely event" sounds sad and unproductive, "Single event" like it's the only event on a day… happy about input here! ;)
Other changes
This fixes the displaying of past events when set to "inactive", but the option "show submenu" is turned on. Previously, past events were only correcly shown as "inactive" when the sub menu was disabled, because the sub menu was otherwise not accessible on a disable item. I changed it to use the system's disabledControlTextColor for the font, instead of disabling them. This makes the item look like the same, but keeps the sub menu usable.
I also sorted the files in Xcode's project navigator a little bit by their importance. If this is unwanted, I'm happy to undo that.
Steps to Test or Reproduce
Prep

Create calendar event A, and invite someone to it
Create calendar event B, where you invite nobody
Test

Make sure both events show up as usual in the main menu
Set the setting for Events without guests to hide or show as inactive.
Make sure event B is not showing or showing with muted/gray text
Wait until event A starts, make sure you get the notification and the status bar title is set
Wait until event B happens, make sure you don't get the notification, and the status bar title ignores event B.