### PR TITLE
support Chromium as an executable for meet/hangouts

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -144,3 +144,9 @@ enum GoogleRegex {
 public enum AutoLauncher {
     static let bundleIdentifier: String = "leits.MeetingBar.AutoLauncher"
 }
+
+enum ChromeExecutable {
+    case chrome = "Google Chrome"
+    case chromium = "Chromium"
+    case defaultBrowser = "Default Browser"
+}

--- a/MeetingBar/DefaultsKeys.swift
+++ b/MeetingBar/DefaultsKeys.swift
@@ -35,8 +35,8 @@ extension Defaults.Keys {
 
     // Integrations
     static let createMeetingService = Key<CreateMeetingServices>("createMeetingService", default: .zoom)
-    static let useChromeForMeetLinks = Key<Bool>("useChromeForMeetLinks", default: false)
-    static let useChromeForHangoutsLinks = Key<Bool>("useChromeForHangoutsLinks", default: false)
+    static let useChromeForMeetLinks = Key<ChromeExecutable>("useChromeForMeetLinks", default: .defaultBrowser)
+    static let useChromeForHangoutsLinks = Key<ChromeExecutable>("useChromeForHangoutsLinks", default: .defaultBrowser)
     static let useAppForZoomLinks = Key<Bool>("useAppForZoomLinks", default: false)
     static let useAppForTeamsLinks = Key<Bool>("useAppForTeamsLinks", default: false)
 

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -32,6 +32,20 @@ func openLinkInChrome(_ link: URL) {
     }
 }
 
+func openLinkInChromium(_ link: URL) {
+    let configuration = NSWorkspace.OpenConfiguration()
+    let chromeUrl = URL(fileURLWithPath: "/Applications/Chromium.app")
+    NSWorkspace.shared.open([link], withApplicationAt: chromeUrl, configuration: configuration) { app, error in
+        if app != nil {
+            NSLog("Open \(link) in Chromium")
+        } else {
+            NSLog("Can't open \(link) in Chromium: \(String(describing: error?.localizedDescription))")
+            sendNotification("Oops! Unable to open the link in Chromium", "Make sure you have Chromium installed, or change the browser in the preferences.")
+            _ = openLinkInDefaultBrowser(link)
+        }
+    }
+}
+
 func openLinkInDefaultBrowser(_ link: URL) -> Bool {
     let result = NSWorkspace.shared.open(link)
     if result {

--- a/MeetingBar/PreferencesView.swift
+++ b/MeetingBar/PreferencesView.swift
@@ -269,12 +269,14 @@ struct Configuration: View {
         VStack(alignment: .leading, spacing: 15) {
             Section {
                 Picker(selection: $useChromeForMeetLinks, label: Text("Open Meet links in").frame(width: 150, alignment: .leading)) {
-                    Text("Default Browser").tag(false)
-                    Text("Chrome").tag(true)
+                    Text("Default Browser").tag(ChromeExecutable.defaultBrowser)
+                    Text("Chrome").tag(ChromeExecutable.chrome)
+                    Text("Chromium").tag(ChromeExecutable.chromium)
                 }
                 Picker(selection: $useChromeForHangoutsLinks, label: Text("Open Hangouts links in").frame(width: 150, alignment: .leading)) {
-                    Text("Default Browser").tag(false)
-                    Text("Chrome").tag(true)
+                    Text("Default Browser").tag(ChromeExecutable.defaultBrowser)
+                    Text("Chrome").tag(ChromeExecutable.chrome)
+                    Text("Chromium").tag(ChromeExecutable.chromium)
                 }
                 Picker(selection: $useAppForZoomLinks, label: Text("Open Zoom links in").frame(width: 150, alignment: .leading)) {
                     Text("Default Browser").tag(false)

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -470,9 +470,12 @@ func getMeetingLink(_ event: EKEvent) -> (service: MeetingServices?, url: URL)? 
 func openMeetingURL(_ service: MeetingServices?, _ url: URL) {
     switch service {
     case .meet:
-        if Defaults[.useChromeForMeetLinks] {
+        switch Defaults[.useChromeForMeetLinks] {
+        case .chrome:
             openLinkInChrome(url)
-        } else {
+        case .chromium:
+            openLinkInChromium(url)
+        default:
             _ = openLinkInDefaultBrowser(url)
         }
     case .hangouts:


### PR DESCRIPTION
Status
READY

Description
hey there! first off, huge fan of the software.

i'm a chromium user so thought it'd be nice to add chromium as a potential target for google chrome specific tasks (meet/hangouts). this is a quick patch to get that supported.

note that i lazily created another function, openLinkInChromium; this could be done more cleverly with the original openLinkInChrome function if desired, avoiding some duplicated code (e.g. pass in app path and error string)

i have not written swift or developed for Apple systems before, so this may be way off the mark as far as style goes. happy to hear feedback! thanks for taking the time to look at this.

Steps to Test or Reproduce
no special steps needed